### PR TITLE
Update serializer-options.ts

### DIFF
--- a/src/serializer-options.ts
+++ b/src/serializer-options.ts
@@ -5,7 +5,7 @@ export interface SerializerOptions {
   id: string,
   attributes: Array<string>,
   topLevelLinks?: Links,
-  keyForAttribute?: (attribute: string) => string | caseOptions,
+  keyForAttribute?: ((attribute: string) => string) | caseOptions,
   ref?: string | boolean | Function,
   typeForAttribute?: (attribute: any, user: any) => any,
   nullIfMissing?: boolean,


### PR DESCRIPTION
Add brackets, the are nesseary, otherwise:

keyForAttribute: 'CamelCase' not possible 
=>
[ts]
Argument of type '{ id: string; attributes: string[]; keyForAttribute: string; }' is not assignable to parameter of type 'SerializerOptions'.
  Types of property 'keyForAttribute' are incompatible.
    Type 'string' is not assignable to type '(attribute: string) => string'.
(property) SerializerOptions.attributes: string[]
